### PR TITLE
Fix u2f error in Firefox

### DIFF
--- a/app/scripts/controllers/signMsgCtrl.js
+++ b/app/scripts/controllers/signMsgCtrl.js
@@ -55,7 +55,7 @@ var signMsgCtrl = function($scope, $sce, walletService) {
                 var app = new ledgerEth($scope.wallet.getHWTransport());
                 var localCallback = function(signed, error) {
                     if (typeof error != "undefined") {
-                        error = error.errorCode ? u2f.getErrorByCode(error.errorCode) : error;
+                        error = error.errorCode ? u2fapi.getErrorByCode(error.errorCode) : error;
                         if (callback !== undefined) callback({
                             isError: true,
                             error: error
@@ -80,7 +80,7 @@ var signMsgCtrl = function($scope, $sce, walletService) {
                 var msg = ethUtil.hashPersonalMessage(ethUtil.toBuffer(thisMessage));
                 var localCallback = function(signed, error) {
                     if (typeof error != "undefined") {
-                        error = error.errorCode ? u2f.getErrorByCode(error.errorCode) : error;
+                        error = error.errorCode ? u2fapi.getErrorByCode(error.errorCode) : error;
                         $scope.notifier.danger(error);
                         return;
                     }

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -64,7 +64,7 @@ if (IS_CX) {
     var trezorConnect        = require('./staticJS/trezorConnect');
     var digitalBitboxUsb     = require('./staticJS/digitalBitboxUsb');
     var digitalBitboxEth     = require('./staticJS/digitalBitboxEth');
-    window.u2f               = u2f;
+    window.u2fapi            = u2f;
     window.Ledger3           = ledger3;
     window.ledgerEth         = ledgerEth;
     window.TrezorConnect     = trezorConnect.TrezorConnect;

--- a/app/scripts/staticJS/digitalBitboxUsb.js
+++ b/app/scripts/staticJS/digitalBitboxUsb.js
@@ -1,5 +1,5 @@
 /**
- *  (c) 2017 Douglas Bakkum, Shift Devices AG 
+ *  (c) 2017 Douglas Bakkum, Shift Devices AG
  *  MIT license
 **/
 
@@ -22,7 +22,7 @@ DigitalBitboxUsb.normal64 = function(base64) {
 DigitalBitboxUsb.prototype.u2fCallback = function(response, callback) {
     if ('signatureData' in response) {
         var data = new Buffer((DigitalBitboxUsb.normal64(response.signatureData)), 'base64');
-        if (data.length > 7) 
+        if (data.length > 7)
             callback(data.slice(5));
         else
             return;// Empty frame received, wait for data
@@ -47,7 +47,7 @@ DigitalBitboxUsb.prototype.exchange = function(msg, callback) {
             version: 'U2F_V2',
             keyHandle: DigitalBitboxUsb.webSafe64(kh.toString('base64')),
         };
-        u2f.sign(location.origin, DigitalBitboxUsb.webSafe64(challenge.toString('base64')), [key], localCallback, this.timeoutSeconds);	
+        u2fapi.sign(location.origin, DigitalBitboxUsb.webSafe64(challenge.toString('base64')), [key], localCallback, this.timeoutSeconds);	
     }
 }
 

--- a/app/scripts/staticJS/ledger3.js
+++ b/app/scripts/staticJS/ledger3.js
@@ -57,12 +57,12 @@ Ledger3.prototype.exchange = function(apduHex, callback) {
 	var challenge = new Buffer("0000000000000000000000000000000000000000000000000000000000000000", 'hex');
 	var key = {};
 	key['version'] = 'U2F_V2';
-	key['keyHandle'] = Ledger3.webSafe64(keyHandle.toString('base64'));	
+	key['keyHandle'] = Ledger3.webSafe64(keyHandle.toString('base64'));
 	var self = this;
 	var localCallback = function(result) {
 		self.u2fCallback(result, callback);
 	}
-	u2f.sign(location.origin, Ledger3.webSafe64(challenge.toString('base64')), [key], localCallback, this.timeoutSeconds);	
+	u2fapi.sign(location.origin, Ledger3.webSafe64(challenge.toString('base64')), [key], localCallback, this.timeoutSeconds);
 }
 
 module.exports = Ledger3

--- a/app/scripts/uiFuncs.js
+++ b/app/scripts/uiFuncs.js
@@ -62,7 +62,7 @@ uiFuncs.signTxLedger = function(app, eTx, rawTx, txData, old, callback) {
     var txToSign = ethUtil.rlp.encode(toHash);
     var localCallback = function(result, error) {
         if (typeof error != "undefined") {
-            error = error.errorCode ? u2f.getErrorByCode(error.errorCode) : error;
+            error = error.errorCode ? u2fapi.getErrorByCode(error.errorCode) : error;
             if (callback !== undefined) callback({
                 isError: true,
                 error: error
@@ -83,7 +83,7 @@ uiFuncs.signTxLedger = function(app, eTx, rawTx, txData, old, callback) {
 uiFuncs.signTxDigitalBitbox = function(eTx, rawTx, txData, callback) {
     var localCallback = function(result, error) {
         if (typeof error != "undefined") {
-            error = error.errorCode ? u2f.getErrorByCode(error.errorCode) : error;
+            error = error.errorCode ? u2fapi.getErrorByCode(error.errorCode) : error;
             if (callback !== undefined) callback({
                 isError: true,
                 error: error


### PR DESCRIPTION
Closes #7. This is a wee bit hacky, but simply renames the assignment of `window.u2f = u2f;` to `window.u2fapi = u2f;` and changes all reference in code from `u2f` to `u2fapi`. This is because `window.u2f` is a read-only property in Firefox, and throws if you try to set it.

I hope altering the staticJS files isn't too much sacrilege.