### PR TITLE
Re-enable footer controller

### DIFF
--- a/app/includes/footer.tpl
+++ b/app/includes/footer.tpl
@@ -8,7 +8,7 @@
     </p>
   </div>
 </section>
-<footer class="footer" role="content" aria-label="footer">
+<footer class="footer" role="content" aria-label="footer" ng-controller="footerCtrl">
 
   <article class="block__wrap" style="max-width: 1780px; margin: auto;">
 


### PR DESCRIPTION
Closes #6. The footer element lost its `ng-controller` attribute at some point, which disabled some behavior like the disclaimer modal. This adds it back. Let me know if this was removed for an intentional reason, I noticed that the new footer is much more stripped down (No block #, for instance.)