### PR TITLE
Token fixes

### DIFF
--- a/app/scripts/controllers/tabsCtrl.js
+++ b/app/scripts/controllers/tabsCtrl.js
@@ -67,6 +67,9 @@ var tabsCtrl = function($scope, globalService, $translate, $sce) {
         curNode = $scope.nodeList[key];
       } else {
         curNode = $scope.nodeList[$scope.defaultNodeKey];
+        globalFuncs.localStorage.setItem('curNode', JSON.stringify({
+            key: $scope.defaultNodeKey
+        }));
       }
       return curNode;
     }
@@ -88,13 +91,13 @@ var tabsCtrl = function($scope, globalService, $translate, $sce) {
 
         $scope.dropdownNode = false;
         Token.popTokens = $scope.curNode.tokenList;
-        ajaxReq['key'] = key;
+        ajaxReq['key'] = newNode.key;
         for (var attrname in $scope.curNode.lib) ajaxReq[attrname] = $scope.curNode.lib[attrname];
         for (var attrname in $scope.curNode)
             if (attrname != 'name' && attrname != 'tokenList' && attrname != 'lib')
                 ajaxReq[attrname] = $scope.curNode[attrname];
-            globalFuncs.localStorage.setItem('curNode', JSON.stringify({
-            key: key
+        globalFuncs.localStorage.setItem('curNode', JSON.stringify({
+            key: newNode.key
         }));
         if (nodes.ensNodeTypes.indexOf($scope.curNode.type) == -1) $scope.tabNames.ens.cx = $scope.tabNames.ens.mew = false;
         if (nodes.domainsaleNodeTypes.indexOf($scope.curNode.type) == -1) $scope.tabNames.domainsale.cx = $scope.tabNames.domainsale.mew = false;

--- a/app/scripts/directives/balanceDrtv.html
+++ b/app/scripts/directives/balanceDrtv.html
@@ -136,7 +136,7 @@
   <div class="block token-balances">
     <h5 translate="sidebar_TokenBal">Token Balances</h5>
 
-    <!-- Load Token Balances -->
+    <!-- Load Token Balances
     <a class="btn btn-warning btn-xs"
        ng-click="wallet.setTokens(); globalService.tokensLoaded=true"
        ng-hide="globalService.tokensLoaded">
@@ -144,10 +144,19 @@
       Load Tokens
     </a>
     <br ng-hide="globalService.tokensLoaded" /><br ng-hide="globalService.tokensLoaded" />
+    -->
 
     <!-- you can your Balance on Blockchain Explorer -->
-    <p class="u__protip">
-      Remember, you can always view your Balances On
+    <h5 class="u__protip">
+      <a href="https://support.mycrypto.com/tokens/adding-new-token-and-sending-custom-tokens.html"
+         rel="noopener noreferrer"
+         target="_blank">
+         How to See Your Tokens
+      </a>
+    </h5>
+
+    <p>
+      You can also view your Balances on
       <a ng-show="ajaxReq.type != 'CUS'"
          href="{{ajaxReq.blockExplorerAddr.replace('[[address]]', wallet.getAddressString())}}"
          target="_blank"
@@ -201,6 +210,30 @@
       <button class="btn btn-primary btn-xs" ng-click="saveTokenToLocal()" translate="x_Save">Save</button>
 
     </div>
+
+    <br/>
+    <br/>
+
+    <!-- Balances -->
+    <table class="account-info">
+      <tr ng-class="token.type!=='default' ? 'custom-token' : ''"
+          ng-repeat="token in wallet.tokenObjs track by $index"
+          ng-hide="(token.balance==0 || token.balance=='Click to Load') && showAllTokens==false">
+        <td class="mono wrap point">
+          <img src="images/icon-remove.svg"
+               class="token-remove"
+               title="Remove Token"
+               ng-click="removeTokenFromLocal(token.symbol)"
+               ng-show="token.type!=='default'" />
+          <span ng-click="setAndVerifyBalance(token)">
+            {{ token.getBalance() }}
+          </span>
+        </td>
+        <td>
+          {{ token.getSymbol() }}
+        </td>
+      </tr>
+    </table>
   </div>
 
 

--- a/app/scripts/nodes.js
+++ b/app/scripts/nodes.js
@@ -220,6 +220,11 @@ nodes.nodeList = {
     }
 };
 
+// add a 'key' attribute to each node that is its object key
+Object.keys(nodes.nodeList).forEach(function(key) {
+    nodes.nodeList[key].key = key;
+});
+
 
 nodes.ethPrice = require('./nodeHelpers/ethPrice');
 module.exports = nodes;


### PR DESCRIPTION
Closes #5. Fixes two main issues:

1. If you had `curNode: {"key": "eth_mew"}` in local storage, it would never get updated to `eth_mycrypto` due to the way local storage saving happens. Subsequent checks against this key in LS would then be messed up.
2. The token balances directive markup was somehow missing a bunch of stuff and out of date from when we forked, so tokens weren't rendering at all.

It's workin' like a charm now:

![screen shot 2018-02-06 at 6 31 55 am](https://user-images.githubusercontent.com/649992/35857528-75f492b6-0b07-11e8-9c0f-c1c2426c8006.png)
