### PR TITLE
Add version to footer

### DIFF
--- a/app/includes/footer.tpl
+++ b/app/includes/footer.tpl
@@ -20,7 +20,7 @@
         MyCrypto is an open-source, client-side tool for interacting with the blockchain more easily. Developed by and for the community since 2015, we’re focused on building awesome products that put the power in people’s hands.
       </p>
       <p class="copyright">
-        © 2018 MyCrypto, Inc.
+        © 2018 MyCrypto, Inc · v{{version}}
       </p>
     </section>
 

--- a/app/includes/footer.tpl
+++ b/app/includes/footer.tpl
@@ -8,7 +8,7 @@
     </p>
   </div>
 </section>
-<footer class="footer" role="content" aria-label="footer">
+<footer class="footer" role="content" aria-label="footer" ng-controller="footerCtrl">
 
   <article class="block__wrap" style="max-width: 1780px; margin: auto;">
 

--- a/app/scripts/controllers/footerCtrl.js
+++ b/app/scripts/controllers/footerCtrl.js
@@ -1,6 +1,9 @@
 'use strict';
+
 var footerCtrl = function($scope, globalService) {
     var gasPriceKey = "gasPrice";
+    var packageJson = require('../../../package.json');
+    $scope.version = packageJson.version;
     $scope.footerModal = new Modal(document.getElementById('disclaimerModal'));
     $scope.ethBlockNumber = "loading";
     $scope.etcBlockNumber = "loading";


### PR DESCRIPTION
Relies on #9. For the purposes of diagnosing issues, having the version somewhere on the page can be very useful. Since the header has been reworked, this just adds it in to the footer.

![screen shot 2018-02-06 at 6 45 58 am](https://user-images.githubusercontent.com/649992/35858169-8052d8c4-0b09-11e8-8c66-b349e5381295.png)
