### PR TITLE
adding ENTRP as token

### DIFF
--- a/app/scripts/tokens/ethTokens.json
+++ b/app/scripts/tokens/ethTokens.json
@@ -2313,4 +2313,9 @@
 "symbol":"ZST",
 "decimal":8,
 "type":"default"
+}{
+"address":"0x5BC7e5f0Ab8b2E10D2D0a3F21739FCe62459aeF3",
+"symbol":"ENTRP",
+"decimal":18,
+"type":"default"
 }]


### PR DESCRIPTION
Hello Taylor and Team - I'm adding our token following a successful crowdsale last year;

https://hut34.io/ is the website, admin@hut34.io is the support address, https://t.me/hut34 is the Telegram Group.

The Entropy token (ENTRP) powers the Hut34 Network, building a marketplace for data where bots, IoT devices, A.I. instances and even people, through which you can connect, route, resolve and monetise queries.

My name is Peter, a co-founder, and my email is peter@hut34.io.

Good luck settling down after your recent bumps and bashes, and purely as a user and beneficiary of your outstanding work, many thanks!

best,

Peter.