### PR TITLE
Fix Keystore not downloading

### DIFF
--- a/app/includes/generateWallet.tpl
+++ b/app/includes/generateWallet.tpl
@@ -157,7 +157,7 @@
          aria-label="{{'x_Download'|translate}} {{'x_Keystore'|translate}}"
          aria-describedby="x_KeystoreDesc"
          ng-click="downloaded()"
-         target="_blank" rel="noopener noreferrer">
+         rel="noopener noreferrer">
         <span translate="x_Download">
           DOWNLOAD
         </span>


### PR DESCRIPTION
Removes `target="_blank"` on Keystore download for browser compatibility.

Users are reporting that although a new window is opening, no file download is being initiated. 

Although I can't reproduce, users have had success when the target="_blank" attribute has been removed, so this PR introduces a fix for the MyCrypto codebase.