### PR TITLE
Update Drawbridge Config

### DIFF
--- a/.drawbridgerc
+++ b/.drawbridgerc
@@ -1,5 +1,5 @@
 {
-    //gitUrls will be the same since we don't have separate develop/staging repos
+    //gitUrls will be the same since we don't have separate develop/prod repos
 
     "environments": {
         "develop": {
@@ -7,15 +7,10 @@
             "distFolder": "dist",
             "buildCommand": "npm install && npm run build"
         },
-        "staging": {
+        "prod": {
             "gitUrl": "git@github.com:MyCryptoHQ/mycrypto.com.git",
-            "distFolder": ""            
-        },
-	      "prod": {
-	          "gitUrl": ""
-    	  },
-        "beta": {
-            "gitUrl": ""
+            "distFolder": "",
+            "defaultBranch": "gh-pages"
         }
     }
 }


### PR DESCRIPTION
Correctly renames environment keys and introduces the `defaultBranch` property for `prod`. The `defaultBranch` will be used if no other commit or branch is supplied.

So, a `--toBranch gh-pages` is no longer needed in the following command:
```
drawbridge push develop to prod --fromCommit 33c8346 --commitMessage "3.15.0" --newBranch "release-april-19-2018-1"
```