### PR TITLE
Update ETC mewapi to dedicated dns

### DIFF
--- a/app/scripts/nodes.js
+++ b/app/scripts/nodes.js
@@ -92,7 +92,7 @@ nodes.nodeList = {
         'tokenList': require('./tokens/etcTokens.json'),
         'abiList': require('./abiDefinitions/etcAbi.json'),
         'service': 'epool.io',
-        'lib': new nodes.customNode('https://mewapi.epool.io', '')
+        'lib': new nodes.customNode('https://cry.epool.io', '')
     },
     'rop_infura': {
         'name': 'Ropsten',


### PR DESCRIPTION
The ETC public API is under heavy load, and would be a benefit to dedicate new API to Mycrypto so it is not impacted by general traffic. Thanks