### PR TITLE
Add legacy banner

### DIFF
--- a/app/includes/header.tpl
+++ b/app/includes/header.tpl
@@ -4,6 +4,15 @@
         aria-label="header"
         ng-controller='tabsCtrl'>
 
+
+    @@if (site === 'web' ) {
+    <div class="large announcement annoucement-info">
+        <div class="container">
+            This is the legacy version of MyCrypto. Checkout <a href="https://mycrypto.com">MyCrypto.com</a> for the new version!
+        </div>
+    </div>
+    }
+
     <section class="header__wrap">
       <div class="container">
 


### PR DESCRIPTION
Adds a banner to inform users this codebase is considered "legacy" and links to mycrypto.com for the current site. 

<img width="1440" alt="screen shot 2018-05-13 at 1 48 57 pm" src="https://user-images.githubusercontent.com/7861465/39970650-bfdbe4da-56b4-11e8-9f51-b837642c598a.png">
